### PR TITLE
Create a parser with ExtendedInterpolation

### DIFF
--- a/confight.py
+++ b/confight.py
@@ -12,7 +12,7 @@ import pkg_resources
 try:
     from ConfigParser import ConfigParser
 except ImportError:
-    from configparser import ConfigParser
+    from configparser import ConfigParser, ExtendedInterpolation
 
 import toml
 
@@ -170,7 +170,10 @@ def check_access(path):
 
 
 def load_ini(stream):
-    parser = ConfigParser()
+    if 'ExtendedInterpolation' in globals():
+        parser = ConfigParser(interpolation=ExtendedInterpolation())
+    else:
+        parser = ConfigParser()
     parser.readfp(stream)
     return {
         section: dict(parser.items(section))


### PR DESCRIPTION
In python3, if the configparser does not use ExtendedInterpolation, the following config will fail to load in an ini file:
     repServer=r%HOSTNAME%

A workaround could be to change % to %%, but for legacy configs, its better to use the extended interpolation