### PR TITLE
Fix expand paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ The extension of the configuration file can be given with the `extension`
 parameter. For instance, `load_app('myapp', extension='json')` would look for
 the `/etc/myapp/config.json` file.
 
+All files in the `conf.d` directory are read by default regardless the
+extension. To enforce that only `.extension` files are read, add the
+`force_extension` flag.
+
 ## Parsing
 
 Given a path to an existing configuration file, it will be loaded in memory

--- a/confight.py
+++ b/confight.py
@@ -157,9 +157,10 @@ def find(path):
     :param dir_path: Path to a config file or dir containing configs
     :returns: List of full paths of the files in the directory in lex. order
     """
+    if path:
+        path = os.path.abspath(os.path.expanduser(path))
     if not check_access(path):
         return []
-    path = os.path.abspath(os.path.expanduser(path))
     if os.path.isfile(path):
         return [path]
     return sorted(glob.glob(os.path.join(path, '*')))

--- a/pypiversion.sh
+++ b/pypiversion.sh
@@ -9,5 +9,5 @@ python3 setup.py bdist_wheel
 echo "Generated python packages"
 
 echo "Uploading to test repository"
-twine upload --repository-url https://test.pypi.org/legacy/ dist/*
-#twine upload --repository-url https://upload.pypi.org/legacy/ dist/*
+twine upload --repository pypitest dist/*
+#twine upload --repository pypi dist/*

--- a/test_confight.py
+++ b/test_confight.py
@@ -167,6 +167,15 @@ class TestFind(object):
 
         assert_that(found, contains(path))
 
+    def test_it_should_expand_user_variables(self, tmpdir, examples):
+        path = examples.get(FILES[0])
+        home = os.path.expanduser('~')
+        relpath = os.path.join('~', os.path.relpath(path, start=home))
+
+        found = find(relpath)
+
+        assert_that(found, contains(path))
+
     def test_it_should_return_nothing_for_missing_directories(self):
         assert_that(find('/path/to/nowhere'), is_(empty()))
 


### PR DESCRIPTION
Passing `~/path/to/x` to `find()` was failing because of bad validation.