### PR TITLE
Import pkg_resources only when needed

### DIFF
--- a/confight.py
+++ b/confight.py
@@ -8,7 +8,6 @@ import json
 import logging
 import argparse
 import itertools
-import pkg_resources
 from collections import OrderedDict
 try:
     from ConfigParser import ConfigParser
@@ -244,6 +243,7 @@ def format_from_path(path):
 
 
 def get_version():
+    import pkg_resources
     return 'confight ' + pkg_resources.get_distribution('confight').version
 
 


### PR DESCRIPTION
Importing it is slow and might harm performance on CLI applications
that run many times for a short time.
See https://github.com/pypa/setuptools/issues/510