### PR TITLE
fix(setup): Freeze version of ruamel.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 # Changelog
 
 
+### 1.3.2 (2023-10-25)
+
+  * [241dca89] Update ownership to Platform Operability
+  * [96a1def0] fix(setup): Freeze version of `ruamel.yaml`
+
+### 1.3.1 (2020-04-28)
+
+  * [f6183081] Adds tests for ignore load file behaviour
+  * [9686602f] Import pkg_resources only when needed
+  * [7e7cbe5c] Update README with optional dependencies
+  * [a766b09f] Pin hamcrest version to be python3.5 compatible
+
 ### 1.3 (2019-09-19)
 
   * [995d00f6] Adds a default config parameter for the load_app family of functions

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+confight (1.3.2) Ubuntu; urgency=medium
+
+  * [241dca89] Update ownership to Platform Operability
+  * [96a1def0] fix(setup): Freeze version of `ruamel.yaml`
+
+ -- Frank Lenormand <frank.lenormand@avature.net>  Wed, 25 Oct 2023 16:49:30 +0200
+
 confight (1.3.1) unstable; urgency=medium
 
   * [f6183081] Adds tests for ignore load file behaviour

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     py_modules=['confight'],
     install_requires=io.open('requirements.txt').read().splitlines(),
     extras_require={
-        'yaml': ["ruamel.yaml"],
+        'yaml': ["ruamel.yaml==0.17.40"],
     },
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This commit freezes the version of the `ruamel.yaml` dependency, and mitigates
the following error that occurs with more recent (v0.18.x) versions:

```
AttributeError:
"load()" has been removed, use
  yaml = YAML(typ='rt')
  yaml.load(...)
and register any classes that you use, or check the tag attribute on the loaded data,
instead of file "/opt/iadm/lib/python3.11/site-packages/confight.py", line 222
        return yaml.load(stream, Loader=yaml.RoundTripLoader)
```