### PR TITLE
feat: adds support for HCL language

### DIFF
--- a/confight.py
+++ b/confight.py
@@ -214,12 +214,13 @@ FORMAT_LOADERS = {
 
 # Optional dependency yaml
 try:
-    import ruamel.yaml as yaml
+    from ruamel.yaml import YAML
 except ImportError:
     pass
 else:
     def load_yaml(stream):
-        return yaml.load(stream, Loader=yaml.RoundTripLoader)
+        yaml = YAML(typ="rt")
+        return yaml.load(stream)
 
     FORMATS = FORMATS + ('yaml',)
     FORMAT_EXTENSIONS.update({
@@ -228,6 +229,23 @@ else:
     })
     FORMAT_LOADERS.update({
         'yaml': load_yaml
+    })
+
+# Optional dependency HCL
+try:
+    import hcl
+except ImportError:
+    pass
+else:
+    def load_hcl(stream):
+        return hcl.load(stream)
+
+    FORMATS = FORMATS + ('hcl',)
+    FORMAT_EXTENSIONS.update({
+        'hcl': 'hcl'
+    })
+    FORMAT_LOADERS.update({
+        'hcl': load_hcl
     })
 
 

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     install_requires=io.open('requirements.txt').read().splitlines(),
     extras_require={
         'yaml': ["ruamel.yaml==0.17.40"],
+        'hcl': ["pyhcl==0.4.5"],
     },
     entry_points={
         'console_scripts': [

--- a/test_confight.py
+++ b/test_confight.py
@@ -28,6 +28,8 @@ FILES = [
 ]
 if "yaml" in FORMATS:
     FILES.extend(["basic_file.yaml", "basic_file.yml"])
+if "hcl" in FORMATS:
+    FILES.extend(["basic_file.hcl"])
 
 INVALID_FILES = [
     'invalid.toml', 'invalid.ini', 'invalid.json', 'invalid.cfg', 'invalid.js'
@@ -589,6 +591,17 @@ section:
         - fourth
     unicode: "💩"
 """,
+        'basic_file.hcl': u"""
+    section {
+        string = "hcl"
+        integer = 3
+        float = 3.5
+        boolean = false
+        "null" = null
+        list = [ third, fourth ]
+        unicode = "💩"
+    }
+    """,
         'invalid.toml': """
 [section]
 key = null
@@ -627,3 +640,5 @@ key = second
     _contents['bad_ext.u'] = _contents['basic_file.yaml']
     _contents['basic_file_yaml'] = _contents['basic_file.yaml']
     _contents['basic_file.yml'] = _contents['basic_file.yaml']
+    _contents['basic_file_hcl'] = _contents['basic_file.hcl']
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
-envlist = py{27,35,36,37}-{basic,yaml}
+envlist = py{27,35,36,37}-{basic,yaml,hcl}
 skip_missing_interpreters=True
 
 [testenv]
 deps =
     -r{toxinidir}/dev-requirements.txt
     yaml: ruamel.yaml
+    hcl: pyhcl
 commands=python -m pytest


### PR DESCRIPTION
Uses `pyhcl` to enable parsing of files in [HCL format](https://developer.hashicorp.com/terraform/language).

Solves #13 