### PR TITLE
fix(setup): Make the list of classifiers a list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,12 +33,12 @@ setup(
             'confight = confight:cli',
         ]
     },
-    classifiers=(
+    classifiers=[
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-    ),
+    ],
 )


### PR DESCRIPTION
This commit addresses the following warning:

	Warning: 'classifiers' should be a list, got type 'tuple'

Closes #20.

Reference:
https://github.com/pypi/legacy/issues/670