### PR TITLE
Only support Python v3.8+

### DIFF
--- a/confight.py
+++ b/confight.py
@@ -214,12 +214,13 @@ FORMAT_LOADERS = {
 
 # Optional dependency yaml
 try:
-    import ruamel.yaml as yaml
+    from ruamel.yaml import YAML
 except ImportError:
     pass
 else:
     def load_yaml(stream):
-        return yaml.load(stream, Loader=yaml.RoundTripLoader)
+        yaml = YAML(typ="rt")
+        return yaml.load(stream)
 
     FORMATS = FORMATS + ('yaml',)
     FORMAT_EXTENSIONS.update({

--- a/debian/control
+++ b/debian/control
@@ -12,14 +12,6 @@ Build-Depends: debhelper (>= 9),
                pandoc (>= 1.9),
                tox
 
-Package: python-confight
-Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, python-toml, python-setuptools
-Suggests: python-ruamel.yaml
-Description: Common config loading for Python and the command line
- .
- This package installs the library for Python 2.
-
 Package: python3-confight
 Architecture: all
 Depends: ${python3:Depends}, ${misc:Depends}, python3-toml, python3-setuptools

--- a/debian/rules
+++ b/debian/rules
@@ -2,17 +2,16 @@
 # -*- makefile -*-
 
 export PYBUILD_NAME=confight
-DESTDIR2:=debian/python-confight
 DESTDIR3:=debian/python3-confight
 
 %:
-	dh $@ --with python2,python3 --buildsystem=pybuild --tests-pytest
+	dh $@ --with python3 --buildsystem=pybuild --tests-pytest
 
 override_dh_installman:
 	cat docs/man-header.md README.md | \
 	  pandoc --standalone -f markdown -t man | \
 	  tee docs/confight.1 > docs/confight3.1
-	dh_installman --package python-confight docs/confight.1
+	dh_installman --package python3-confight docs/confight.1
 	dh_installman --package python3-confight docs/confight3.1
 
 override_dh_compress:
@@ -20,7 +19,7 @@ override_dh_compress:
 
 override_dh_auto_install:
 	dh_auto_install
-	cd $(DESTDIR3)/usr/bin && mv confight confight3
+	cd $(DESTDIR3)/usr/bin && cp confight confight3
 
 override_dh_clean:
 	rm -f docs/confight.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,2 @@
-pyHamcrest==1.10.1
+pyHamcrest
 pytest
-mock; python_version < '3.6'
-subprocess32; python_version < '3'

--- a/pypiversion.sh
+++ b/pypiversion.sh
@@ -3,8 +3,6 @@ echo "Cleaning dist directory"
 rm -f dist/*
 
 echo "Building python packages"
-python setup.py sdist
-python setup.py bdist_wheel
 python3 setup.py bdist_wheel
 echo "Generated python packages"
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     py_modules=['confight'],
     install_requires=io.open('requirements.txt').read().splitlines(),
     extras_require={
-        'yaml': ["ruamel.yaml==0.17.40"],
+        'yaml': ["ruamel.yaml"],
         'hcl': ["pyhcl"],
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     py_modules=['confight'],
     install_requires=io.open('requirements.txt').read().splitlines(),
     extras_require={
-        'yaml': ["ruamel.yaml"],
+        'yaml': ["ruamel.yaml>=0.18.0"],
         'hcl': ["pyhcl"],
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,10 @@ setup(
         ]
     },
     classifiers=(
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
-        "Programming Language :: Python :: 3.5",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ),

--- a/test_confight.py
+++ b/test_confight.py
@@ -11,7 +11,7 @@ except ImportError:
 
 import pytest
 from hamcrest import (assert_that, has_entry, has_key, has_entries, is_, empty,
-                      only_contains, contains, contains_string)
+                      only_contains, contains_exactly, contains_string)
 
 from confight import (parse, merge, find, load, load_paths, load_app,
                       load_user_app, FORMATS)
@@ -160,14 +160,14 @@ class TestFind(object):
 
         found = find(path)
 
-        assert_that(found, contains(__file__))
+        assert_that(found, contains_exactly(__file__))
 
     def test_it_should_load_existing_files(self, examples):
         path = examples.get(FILES[0])
 
         found = find(path)
 
-        assert_that(found, contains(path))
+        assert_that(found, contains_exactly(path))
 
     def test_it_should_expand_user_variables(self, tmpdir, examples):
         path = examples.get(FILES[0])
@@ -176,7 +176,7 @@ class TestFind(object):
 
         found = find(relpath)
 
-        assert_that(found, contains(path))
+        assert_that(found, contains_exactly(path))
 
     def test_it_should_return_nothing_for_missing_directories(self):
         assert_that(find('/path/to/nowhere'), is_(empty()))
@@ -209,7 +209,7 @@ class TestFind(object):
 
         found = find(executable_file)
 
-        assert_that(found, contains(executable_file))
+        assert_that(found, contains_exactly(executable_file))
         logger.warning.assert_called()
 
 
@@ -284,7 +284,7 @@ class TestLoadPaths(object):
             'subsection', 'null'
         ]
 
-        assert_that(config["section"].keys(), contains(*good_data))
+        assert_that(config["section"].keys(), contains_exactly(*good_data))
 
 
 class LoadAppBehaviour(object):
@@ -313,35 +313,35 @@ class TestLoadApp(LoadAppBehaviour):
     def test_it_should_load_from_default_path(self):
         config = self.load_app('myapp')
 
-        assert_that(self.loaded_paths(config), contains(
+        assert_that(self.loaded_paths(config), contains_exactly(
             '/etc/myapp/config.toml', '/etc/myapp/conf.d',
         ))
 
     def test_it_should_be_able_to_ignore_file(self):
         config = self.load_app('myapp', file_path=None)
 
-        assert_that(self.loaded_paths(config), contains(
+        assert_that(self.loaded_paths(config), contains_exactly(
             '/etc/myapp/conf.d',
         ))
 
     def test_it_should_be_able_to_ignore_directory(self):
         config = self.load_app('myapp', dir_path=None)
 
-        assert_that(self.loaded_paths(config), contains(
+        assert_that(self.loaded_paths(config), contains_exactly(
             '/etc/myapp/config.toml',
         ))
 
     def test_it_should_load_extra_paths(self):
         config = self.load_app('myapp', paths=['/extra/path'])
 
-        assert_that(self.loaded_paths(config), contains(
+        assert_that(self.loaded_paths(config), contains_exactly(
             '/etc/myapp/config.toml', '/etc/myapp/conf.d', '/extra/path'
         ))
 
     def test_it_should_add_default_as_priority_location(self):
         config = self.load_app('myapp', default='/path/to/default')
 
-        assert_that(self.loaded_paths(config), contains(
+        assert_that(self.loaded_paths(config), contains_exactly(
             '/path/to/default',
             '/etc/myapp/config.toml',
             '/etc/myapp/conf.d',
@@ -350,7 +350,7 @@ class TestLoadApp(LoadAppBehaviour):
     def test_it_should_allow_using_known_extensions(self):
         config = self.load_app('myapp', extension='json')
 
-        assert_that(self.loaded_paths(config), contains(
+        assert_that(self.loaded_paths(config), contains_exactly(
             '/etc/myapp/config.json', '/etc/myapp/conf.d',
         ))
 
@@ -361,14 +361,14 @@ class TestLoadApp(LoadAppBehaviour):
     def test_it_should_allow_using_custom_extensions_with_format(self):
         config = self.load_app('myapp', extension='jsn', format='json')
 
-        assert_that(self.loaded_paths(config), contains(
+        assert_that(self.loaded_paths(config), contains_exactly(
             '/etc/myapp/config.jsn', '/etc/myapp/conf.d',
         ))
 
     def test_it_should_use_prefix_for_default_locations(self):
         config = self.load_app('myapp', prefix='/my/path')
 
-        assert_that(self.loaded_paths(config), contains(
+        assert_that(self.loaded_paths(config), contains_exactly(
             '/my/path/config.toml', '/my/path/conf.d',
         ))
 
@@ -381,7 +381,7 @@ class TestLoadUserApp(LoadAppBehaviour):
     def test_it_should_load_from_default_user_path(self):
         config = self.load_app('myapp')
 
-        assert_that(self.loaded_paths(config), contains(
+        assert_that(self.loaded_paths(config), contains_exactly(
             '/etc/myapp/config.toml',
             '/etc/myapp/conf.d',
             '~/.config/myapp/config.toml',
@@ -391,7 +391,7 @@ class TestLoadUserApp(LoadAppBehaviour):
     def test_it_should_load_extra_paths(self):
         config = self.load_app('myapp', paths=['/extra/path'])
 
-        assert_that(self.loaded_paths(config), contains(
+        assert_that(self.loaded_paths(config), contains_exactly(
             '/etc/myapp/config.toml',
             '/etc/myapp/conf.d',
             '~/.config/myapp/config.toml',
@@ -402,7 +402,7 @@ class TestLoadUserApp(LoadAppBehaviour):
     def test_it_should_allow_using_known_extensions(self):
         config = self.load_app('myapp', extension='json')
 
-        assert_that(self.loaded_paths(config), contains(
+        assert_that(self.loaded_paths(config), contains_exactly(
             '/etc/myapp/config.json',
             '/etc/myapp/conf.d',
             '~/.config/myapp/config.json',
@@ -416,7 +416,7 @@ class TestLoadUserApp(LoadAppBehaviour):
     def test_it_should_allow_using_custom_extensions_with_format(self):
         config = self.load_app('myapp', extension='jsn', format='json')
 
-        assert_that(self.loaded_paths(config), contains(
+        assert_that(self.loaded_paths(config), contains_exactly(
             '/etc/myapp/config.jsn',
             '/etc/myapp/conf.d',
             '~/.config/myapp/config.jsn',
@@ -426,7 +426,7 @@ class TestLoadUserApp(LoadAppBehaviour):
     def test_it_should_use_prefix_for_default_locations(self):
         config = self.load_app('myapp', prefix='/my/path')
 
-        assert_that(self.loaded_paths(config), contains(
+        assert_that(self.loaded_paths(config), contains_exactly(
             '/my/path/config.toml',
             '/my/path/conf.d',
             '~/.config/myapp/config.toml',
@@ -436,7 +436,7 @@ class TestLoadUserApp(LoadAppBehaviour):
     def test_it_should_use_prefix_for_default_user_locations(self):
         config = self.load_app('myapp', user_prefix='/my/path')
 
-        assert_that(self.loaded_paths(config), contains(
+        assert_that(self.loaded_paths(config), contains_exactly(
             '/etc/myapp/config.toml',
             '/etc/myapp/conf.d',
             '/my/path/config.toml',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36,37}-{basic,yaml,hcl}
+envlist = py{38,39,310,311}-{basic,yaml,hcl}
 skip_missing_interpreters=True
 
 [testenv]


### PR DESCRIPTION
This commit assumes the `ruamel.yaml` dependency and its use were adjusted.

Closes #12.

Reference: #18