### PR TITLE
Avoid overriding confight binary

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -19,7 +19,7 @@ override_dh_compress:
 
 override_dh_auto_install:
 	dh_auto_install
-	cd $(DESTDIR3)/usr/bin && cp confight confight3
+	cd $(DESTDIR3)/usr/bin && mv confight confight3
 
 override_dh_clean:
 	rm -f docs/confight.1


### PR DESCRIPTION
```
OUT => dpkg: error processing archive /tmp/apt-dpkg-install-cSTQku/233-python3-confight_2.0_all.deb (--unpack):
OUT =>  trying to overwrite '/usr/bin/confight', which is also in package python-confight 1.4.0
```